### PR TITLE
implement daemonization

### DIFF
--- a/cli2telegram.service_example
+++ b/cli2telegram.service_example
@@ -1,0 +1,28 @@
+[Unit]
+Description=cli2telegram Daemon
+After=syslog.target network.target
+
+[Service]
+# Change the user and group variables here.
+User=cli2telegram
+Group=cli2telegram
+
+Type=simple
+
+# Change the path to cli2telegram here
+ExecStart=/path/to/cli2telegram -d
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+StandardOutput=file:/var/log/cli2telegram.log
+StandardError=file:/var/log/cli2telegram.err
+
+# These lines optionally isolate (sandbox) cli2telegram
+# Make sure to add any paths it might use to the list below (space-separated).
+#ReadWritePaths=/path/to/cli2telegram /path/to/named/pipe
+#ProtectSystem=strict
+#PrivateDevices=true
+#ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/cli2telegram.toml_example
+++ b/cli2telegram.toml_example
@@ -1,3 +1,5 @@
+daemon_pipe_path="/tmp/cli2telegram-"
+
 [telegram]
 bot_token="1234:6783948932dsdsadsadas"
 chat_id="12345678"

--- a/cli2telegram.toml_example
+++ b/cli2telegram.toml_example
@@ -1,4 +1,4 @@
-daemon_pipe_path="/tmp/cli2telegram-"
+daemon_pipe_path="/tmp/cli2telegram"
 
 [telegram]
 bot_token="1234:6783948932dsdsadsadas"

--- a/cli2telegram/cli.py
+++ b/cli2telegram/cli.py
@@ -25,6 +25,7 @@ from telegram.ext import Updater
 
 from cli2telegram.config import Config
 from cli2telegram.util import send_message, prepare_code_message
+from cli2telegram.daemon import Daemon
 
 LOGGER = logging.getLogger(__name__)
 # LOGGER.setLevel(logging.DEBUG)
@@ -38,9 +39,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-b', '--bot-token', 'bot_token', default=None, type=str, help='Telegram Bot Token')
 @click.option('-c', '--chat-id', 'chat_id', default=None, type=str, help='Telegram Chat ID')
+@click.option('-d', '--daemon', 'daemon', default=False, type=bool, help='Daemon mode')
+@click.option('-p', '--pipe', 'pipe', default=None, type=str, help='Daemon mode pipe')
 @click.argument('lines', type=str, nargs=-1)
 @click.version_option()
-def cli(bot_token: str or None, chat_id: str or None, lines: Tuple[str]):
+def cli(bot_token: str or None, chat_id: str or None, lines: Tuple[str], daemon: bool, pipe: str or None):
     """
     cli entry method
     """
@@ -49,7 +52,14 @@ def cli(bot_token: str or None, chat_id: str or None, lines: Tuple[str]):
         CONFIG.TELEGRAM_BOT_TOKEN.value = bot_token
     if chat_id is not None:
         CONFIG.TELEGRAM_CHAT_ID.value = chat_id
+    if pipe is not None:
+        CONFIG.DAEMON_PIPE_PATH.value = pipe
     CONFIG.validate()
+
+    if daemon:
+        d = Daemon(CONFIG)
+        d.run()
+        return
 
     if len(lines) <= 0:
         # read message from stdin

--- a/cli2telegram/config.py
+++ b/cli2telegram/config.py
@@ -73,3 +73,9 @@ class Config(ConfigBase):
         description="Time interval after which the retry should be cancelled.",
         default="1h",
     )
+    DAEMON_PIPE_PATH = StringConfigEntry(
+        key_path=[KEY_ROOT, "daemon_pipe_path"],
+        description="Unix named pipe path.",
+        default="/tmp/cli2telegram-",
+        example="/path/to/some/named/pipe"
+    )

--- a/cli2telegram/config.py
+++ b/cli2telegram/config.py
@@ -76,6 +76,6 @@ class Config(ConfigBase):
     DAEMON_PIPE_PATH = StringConfigEntry(
         key_path=[KEY_ROOT, "daemon_pipe_path"],
         description="Unix named pipe path.",
-        default="/tmp/cli2telegram-",
+        default="/tmp/cli2telegram",
         example="/path/to/some/named/pipe"
     )

--- a/cli2telegram/daemon.py
+++ b/cli2telegram/daemon.py
@@ -1,0 +1,132 @@
+#   cli2telegram
+#  Copyright (c) 2019.  Markus Ressel
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import sys
+import time
+import sys
+import os
+from signal import signal, SIGINT, SIGTERM
+from datetime import datetime
+
+import threading, queue
+
+from telegram.ext import Updater
+
+from cli2telegram.config import Config
+from cli2telegram.util import send_message, prepare_code_message
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+LOGGER.addHandler(handler)
+
+class Daemon:
+    def __init__(self, CONFIG:Config):
+        self.CONFIG = CONFIG
+        self.RUNNING = True
+        self.PIPE_NAME = CONFIG.DAEMON_PIPE_PATH.value
+        self.message_queue = queue.Queue()
+
+    def run(self):
+        try:
+            os.mkfifo(self.PIPE_NAME)
+        except OSError as ose:
+            LOGGER.debug(ose)
+            if os.path.exists(self.PIPE_NAME):
+                raise
+     
+        signal(SIGINT, self.signal_handler) # ctrl+c
+        signal(SIGTERM, self.signal_handler) # systemctl stop
+
+        threading.Thread(target=self.send_message_worker, daemon=True).start()
+
+        LOGGER.info("daemon listening on {}".format(self.PIPE_NAME))
+
+        while True:
+            with open(self.PIPE_NAME) as pipe:
+                LOGGER.debug("wating for input from pipe")
+                pipe_buffer = ''
+                while True:
+                    data = pipe.read()
+                    LOGGER.debug(f"received {data}")
+                    if len(data) == 0 and self.RUNNING:
+                        LOGGER.debug("No data from pipe. Sending buffer to telegram.");
+                        self.message_queue.put(pipe_buffer)
+                        pipe_buffer = ''
+                        break
+                    elif not self.RUNNING:
+                        break
+                    else:
+                        pipe_buffer += data
+            if not self.RUNNING:
+                break
+
+    def send_message_worker(self):
+        while True:
+            message = self.message_queue.get()
+            LOGGER.debug(f"Got {message} from queue. sending...")
+            self._try_send_message(message)
+            self.message_queue.task_done()
+
+    def _try_send_message(self, message: str):
+        """
+        Sends a message
+        :param message: the message to send
+        """
+        started_trying = datetime.now()
+        success = False
+        updater = Updater(token=self.CONFIG.TELEGRAM_BOT_TOKEN.value, use_context=True)
+        while not success:
+            try:
+                chat_id = self.CONFIG.TELEGRAM_CHAT_ID.value
+                send_message(updater.bot, chat_id, message, parse_mode="markdown")
+                success = True
+            except Exception as ex:
+                LOGGER.exception(ex)
+
+                if not self.CONFIG.RETRY_ENABLED.value:
+                    break
+
+                tried_for = datetime.now() - started_trying
+                if tried_for > self.CONFIG.RETRY_GIVE_UP_AFTER.value:
+                    LOGGER.warning(f"Giving up after trying for: {tried_for}. Placing message back in queue.")
+                    self.message_queue.put(message)
+                    break
+
+                timeout_seconds = self.CONFIG.RETRY_TIMEOUT.value.total_seconds()
+                LOGGER.error(f"Error sending message, retrying in {timeout_seconds} seconds...")
+                time.sleep(timeout_seconds)
+
+    def signal_handler(self, signal_received, frame):
+        self.RUNNING = False
+        
+        LOGGER.debug(f"Caught {signal_received}. Attempting to send all messages from queue.")
+        
+        try:
+            os.unlink(self.PIPE_NAME)
+        except OSError as ose:
+            if os.path.exists(self.PIPE_NAME):
+                LOGGER.warning("Unable to clean up named pipe")
+                raise
+        
+        self.message_queue.join()
+
+        sys.exit(0)
+       


### PR DESCRIPTION
This implements the request in #5. To achieve the desired functionality, a named pipe is used, not a socket. A unix socket acts much like a tcp or udp socket; whereas, a named pipe is able to have streams redirected to it.

I'd love feedback and code style critiques.

Added switches:
-d, --daemon: tells cli2telegram whether it should run in daemon mode
-p, --pipe: where the path to the pipe should be

Added config values:
daemon_pipe_path: where the path to the pipe should be

fixes #5