### PR TITLE
Fix error regarding emojize()

### DIFF
--- a/cli2telegram/util.py
+++ b/cli2telegram/util.py
@@ -40,7 +40,7 @@ def send_message(
     :param menu: inline keyboard menu markup
     """
     from emoji import emojize
-    emojized_text = emojize(message, use_aliases=True)
+    emojized_text = emojize(message, language='alias')
     return bot.send_message(
         chat_id=chat_id, parse_mode=parse_mode, text=emojized_text, reply_to_message_id=reply_to, reply_markup=menu,
         timeout=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 container-app-conf==5.2.2
 click
-emoji
+emoji==2.0.0
 python-telegram-bot>=13.10.0


### PR DESCRIPTION
The current version leads - when run as is - to the following compilation error:

```
emojize() got an unexpected keyword argument 'use_aliases'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/cli2telegram/util.py", line 95, in _try_send_message
    send_message(bot=updater.bot, chat_id=chat_id, message=message, parse_mode="markdown")
  File "/usr/local/lib/python3.9/dist-packages/cli2telegram/util.py", line 43, in send_message
    emojized_text = emojize(message, use_aliases=True)
```

This happens because the emoji library was not pinned and changed one of its function.
I adapted the function to emoji 2.0.0 and pinned it.